### PR TITLE
Added test to measure many routes

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -33,7 +33,6 @@ function Route(name, config) {
  * @for Route
  */
 Route.prototype.acceptMethod = function (method) {
-    //TODO support array for method, ['get', 'post']
     return method === this.config.method;
 };
 

--- a/tests/unit/lib/manyroutes.js
+++ b/tests/unit/lib/manyroutes.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2014, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+/*globals describe,it,beforeEach,afterEach */
+"use strict";
+
+var expect = require('chai').expect,
+    Router = require('../../../lib/router'),
+    routes = populateRoutes(),
+    router,
+    start;
+
+function populateRoutes() {
+  var numberOfRoutes = 100000;
+  var routes = {};
+
+  for (var i = 0; i < numberOfRoutes; i++) {
+      routes[i] = {
+          path: '/' + i,
+          method: 'get',
+          page: i
+      };
+  }
+
+  return routes;
+}
+
+describe('ManyRoutes', function () {
+
+    beforeEach(function () {
+        router = new Router(routes);
+    });
+
+    describe('#getRoute', function () {
+        it('existing route', function () {
+            var route = router.getRoute('/9999', {method: 'get'});
+            expect(route.name).to.equal('9999');
+        });
+    });
+});

--- a/tests/unit/lib/manyroutes.js
+++ b/tests/unit/lib/manyroutes.js
@@ -30,8 +30,14 @@ describe('ManyRoutes', function () {
 
     beforeEach(function () {
         router = new Router(routes);
+        start = process.hrtime();
     });
 
+    afterEach(function () {
+       var end = process.hrtime(start);
+       console.log('benchmark took %d ms', (end[0] * 1000) + (end[1] / 1000000));
+    });
+    
     describe('#getRoute', function () {
         it('existing route', function () {
             var route = router.getRoute('/9999', {method: 'get'});


### PR DESCRIPTION
The current implementation of the lookup is very naive.

I suggest either we do array lookup with a predictable pattern string instead of for each key.match
Or one can take a dependency on a trie datastructure which may be a bit more optimized.

I've created a simple test in my local branch called array-lookup which reduces the lookup time from 124ms to ~2ms for 100.000 routes.