### PR TITLE
support query string in the path for route matching

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -40,7 +40,9 @@ Route.prototype.acceptMethod = function (method) {
 /**
  * Checkes whether this route matches the given path, method (GET as default) and optionally navigation related criteria.
  * @method match
- * @param {String} path   The url path to be matched to this route
+ * @param {String} path   The url path to be matched to this route.  Query strings are **not** considered
+ *                        when performing the match.  E.g. /some_path?foo=bar would match to the same route
+ *                        as /some_path
  * @param {Object} [options]
  * @param {String} [options.method=get] The case-insensitive HTTP method string.  Defaults to 'get'.
  * @param {Object} [options.navigate] The navigation info.
@@ -63,7 +65,16 @@ Route.prototype.match = function (path, options) {
         pathMatches,
         routeParams,
         key,
+        i,
+        len,
+        pos,
         pattern;
+
+    // remove query string from path
+    pos = path.indexOf('?');
+    if (pos >= 0) {
+        path = path.substring(0, pos);
+    }
 
     options = options || {};
 
@@ -103,7 +114,7 @@ Route.prototype.match = function (path, options) {
 
     // 4. method/path/navParams all matched, extract the matched path params
     routeParams = {};
-    for (var i = 0, len = self.keys.length; i < len; i++) {
+    for (i = 0, len = self.keys.length; i < len; i++) {
         routeParams[self.keys[i].name] = pathMatches[i+1];
     }
 
@@ -168,7 +179,9 @@ function Router(routes) {
 
 /**
  * @method getRoute
- * @param {String} path   The url path.
+ * @param {String} path   The url path to be used for route matching.  Query strings are **not** considered
+ *                        when performing the match.  E.g. /some_path?foo=bar would match to the same route
+ *                        as /some_path
  * @param {Object} [options]
  * @param {String} [options.method=get] The case-insensitive HTTP method string.
  * @param {Object} [options.navigate] The navigation info.

--- a/tests/unit/lib/router.js
+++ b/tests/unit/lib/router.js
@@ -107,6 +107,9 @@ describe('Router', function () {
 
             route = router.getRoute('/new_article', {method: 'post'});
             expect(route.name).to.equal('new_article');
+
+            route = router.getRoute('/new_article?foo=bar', {method: 'post'});
+            expect(route.name).to.equal('new_article');
         });
 
         it('method should be case-insensitive and defaults to get', function () {


### PR DESCRIPTION
address query string issue reported in https://github.com/yahoo/routr/issues/7

@mridgway @redonkulus @tindli
