### PR TITLE
fix nomenclature: rename "path" to "url"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,9 @@ Routr library is an implementation of router-related functionalities that can be
 For more detailed examples, please check out [example applications](https://github.com/yahoo/routr/tree/master/examples);
 
 ```javascript
-var Router = require('routr'),
-    router,
-    route,
-    path;
+var Router = require('routr');
 
-router = new Router({
+var router = new Router({
     view_user: {
         path: '/user/:id',
         method: 'get',
@@ -34,18 +31,19 @@ router = new Router({
 });
 
 // match route
-route = router.getRoute('/user/garfield');
+var route = router.getRoute('/user/garfield');
 if (route) {
     // this will output:
     //   - "view_user" for route.name
+    //   - "/user/garfield" for route.url
     //   - {id: "garfield"} for route.params
     //   - {path: "/user/:id", method: "get", foo: { bar: "baz"}} for route.config
-    console.log('[Route found]: name=', route.name, 'params=', route.params, 'config=', route.config);
+    console.log('[Route found]:', route);
 }
 
-// generate url path from route
+// generate path name (does not include query string) from route
 // "path" will be "/user/garfield/post/favoriteFood"
-path = router.makePath('view_user_post', {id: 'garfield', post: 'favoriteFood'});
+var path = router.makePath('view_user_post', {id: 'garfield', post: 'favoriteFood'});
 
 ```
 

--- a/examples/server/app.js
+++ b/examples/server/app.js
@@ -28,7 +28,7 @@ router = new Router({
 });
 
 app.all('*', function (req, res) {
-    var route = router.getRoute(req.path, {method: req.method});
+    var route = router.getRoute(req.url, {method: req.method});
     if (route) {
         res.send('[Route found] name=' + route.name + ' params = ' + util.inspect(route.params) + ' config = ' + util.inspect(route.config));
     } else {

--- a/lib/router.js
+++ b/lib/router.js
@@ -5,12 +5,12 @@
 'use strict';
 /*global process:true */
 
-var debug = require('debug')('Routr:router'),
-    pathToRegexp = require('path-to-regexp'),
-    reverend = require('reverend'),
-    METHODS = {
-        GET: 'get'
-    };
+var debug = require('debug')('Routr:router');
+var pathToRegexp = require('path-to-regexp');
+var reverend = require('reverend');
+var METHODS = {
+    GET: 'get'
+};
 
 /**
  * @class Route
@@ -39,11 +39,11 @@ Route.prototype.acceptMethod = function (method) {
 };
 
 /**
- * Checkes whether this route matches the given path, method (GET as default) and optionally navigation related criteria.
+ * Checkes whether this route matches the given url, method (GET as default) and optional navigation related criteria.
  * @method match
- * @param {String} path   The url path to be matched to this route.  Query strings are **not** considered
- *                        when performing the match.  E.g. /some_path?foo=bar would match to the same route
- *                        as /some_path
+ * @param {String} url   The relative url to be matched to this route.  Query strings and hash fragments
+ *                       are **not** considered when performing the match.  E.g. /some_path?foo=bar#hashBaz
+ *                       would match to the same route as /some_path
  * @param {Object} [options]
  * @param {String} [options.method=get] The case-insensitive HTTP method string.  Defaults to 'get'.
  * @param {Object} [options.navigate] The navigation info.
@@ -52,59 +52,63 @@ Route.prototype.acceptMethod = function (method) {
  * @return {Object|null} The matched route params if path/method/navParams matches to this route; null otherwise.
  * @for Route
  */
-Route.prototype.match = function (path, options) {
-    if (!path) {
+Route.prototype.match = function (url, options) {
+    if (!url) {
         return null;
-    }
-
-    var self = this,
-        method,
-        navParams,
-        navParamsConfig,
-        navParamConfigKeys,
-        navParamMatched,
-        pathMatches,
-        routeParams,
-        key,
-        i,
-        len,
-        pos,
-        pattern;
-
-    // remove query string from path
-    pos = path.indexOf('?');
-    if (pos >= 0) {
-        path = path.substring(0, pos);
     }
 
     options = options || {};
 
+    var self = this;
+    var i;
+    var len;
+
     // 1. check method
-    method = (options.method && options.method.toLowerCase()) || METHODS.GET;
+    var method = (options.method && options.method.toLowerCase()) || METHODS.GET;
     if (!self.acceptMethod(method)) {
         return null;
     }
 
     // 2. check path
-    pathMatches = self.regexp.exec(path);
+    // remove query string and hash fragment from url
+    var pos = url.indexOf('?');
+    var path;
+    if (pos >= 0) {
+        // remove query string
+        path = url.substring(0, pos);
+    } else {
+        pos = url.indexOf('#');
+        if (pos >= 0) {
+            // hash fragment does not get sent to server.
+            // But since routr can be used on both server and client,
+            // we should remove hash fragment before matching the regex.
+            path = url.substring(0, pos);
+        } else {
+            path = url;
+        }
+    }
+
+    var pathMatches = self.regexp.exec(path);
     if (!pathMatches) {
         return null;
     }
 
     // 3. check navParams, if this route has match requirements defined for navParams
-    navParamsConfig = (self.config.navigate && self.config.navigate.params);
+    var navParamsConfig = (self.config.navigate && self.config.navigate.params);
     if (navParamsConfig) {
-        navParamConfigKeys = Object.keys(navParamsConfig);
-        navParams = (options.navigate && options.navigate.params) || {};
+        var navParamConfigKeys = Object.keys(navParamsConfig);
+        var navParams = (options.navigate && options.navigate.params) || {};
+        var navParamMatched;
+
         for (i = 0, len = navParamConfigKeys.length; i < len; i++) {
             // for each navParam defined in the route config, make sure
             // the param passed in matches the defined pattern
-            key = navParamConfigKeys[i];
-            pattern = navParamsConfig[key];
+            var configKey = navParamConfigKeys[i];
+            var pattern = navParamsConfig[configKey];
             if (pattern instanceof RegExp) {
-                navParamMatched = navParams[key] !== undefined && pattern.test(navParams[key]);
+                navParamMatched = navParams[configKey] !== undefined && pattern.test(navParams[configKey]);
             } else {
-                navParamMatched = (navParams[key] === pattern);
+                navParamMatched = (navParams[configKey] === pattern);
             }
             if (!navParamMatched) {
                 // found a non-matching navParam -> this route does not match
@@ -114,7 +118,7 @@ Route.prototype.match = function (path, options) {
     }
 
     // 4. method/path/navParams all matched, extract the matched path params
-    routeParams = {};
+    var routeParams = {};
     for (i = 0, len = self.keys.length; i < len; i++) {
         routeParams[self.keys[i].name] = pathMatches[i+1];
     }
@@ -162,9 +166,10 @@ Route.prototype.makePath = function (params) {
     if (route) {
         // this will output:
         //   - "view_user" for route.name
+        //   - "/user/garfield" for route.url
         //   - {id: "garfield"} for route.params
         //   - {path: "/user/:id", method: "get", foo: { bar: "baz"}} for route.config
-        console.log('[Route found]: name=', route.name, 'params=', route.params, 'config=', route.config);
+        console.log('[Route found]: name=', route.name, 'url=', route.url, 'params=', route.params, 'config=', route.config);
     }
  */
 function Router(routes) {
@@ -191,7 +196,7 @@ function Router(routes) {
 
 /**
  * @method getRoute
- * @param {String} path   The url path to be used for route matching.  Query strings are **not** considered
+ * @param {String} url   The url to be used for route matching.  Query strings are **not** considered
  *                        when performing the match.  E.g. /some_path?foo=bar would match to the same route
  *                        as /some_path
  * @param {Object} [options]
@@ -201,21 +206,18 @@ function Router(routes) {
  * @param {Object} [options.navigate.params] The navigation params (that are not part of the path).
  * @return {Object|null} The matched route info if path/method/navigate.params matches to a route; null otherwise.
  */
-Router.prototype.getRoute = function (path, options) {
-    var self = this,
-        keys = Object.keys(self._routes),
-        i,
-        len = keys.length,
-        route,
-        match;
+Router.prototype.getRoute = function (url, options) {
+    var keys = Object.keys(this._routes);
+    var route;
+    var match;
 
-    for (i = 0; i < len; i++) {
-        route = self._routes[keys[i]];
-        match = route.match(path, options);
+    for (var i = 0, len = keys.length; i < len; i++) {
+        route = this._routes[keys[i]];
+        match = route.match(url, options);
         if (match) {
             return {
                 name: keys[i],
-                path: path,
+                url: url,
                 params: match,
                 config: route.config,
                 navigate: options && options.navigate

--- a/tests/unit/lib/router.js
+++ b/tests/unit/lib/router.js
@@ -5,43 +5,43 @@
 /*globals describe,it,beforeEach,process */
 "use strict";
 
-var expect = require('chai').expect,
-    Router = require('../../../lib/router'),
-    routes = {
-        article: {
-            path: '/:site/:category?/:subcategory?/:alias',
-            method: 'get',
-            page: 'viewArticle'
-        },
-        offnetwork_article: {
-            path: '/',
-            method: 'get',
-            navigate: {
-                params: {
-                    id: /^\w{4}\-\w{3}$/,
-                    foo: 'bar'
-                }
-            },
-            page: 'viewArticle'
-        },
-        home: {
-            path: '/',
-            method: 'get',
-            page: 'viewHomepage'
-        },
-        new_article: {
-            path: '/new_article',
-            method: 'post',
-            page: 'createArticle'
-        },
-        custom_match_params: {
-            path: '/posts/:id(\\d+)'
-        },
-        unamed_params: {
-            path: '/:foo/(.*)'
-        }
+var expect = require('chai').expect;
+var Router = require('../../../lib/router');
+var routes = {
+    article: {
+        path: '/:site/:category?/:subcategory?/:alias',
+        method: 'get',
+        page: 'viewArticle'
     },
-    router;
+    offnetwork_article: {
+        path: '/',
+        method: 'get',
+        navigate: {
+            params: {
+                id: /^\w{4}\-\w{3}$/,
+                foo: 'bar'
+            }
+        },
+        page: 'viewArticle'
+    },
+    home: {
+        path: '/',
+        method: 'get',
+        page: 'viewHomepage'
+    },
+    new_article: {
+        path: '/new_article',
+        method: 'post',
+        page: 'createArticle'
+    },
+    custom_match_params: {
+        path: '/posts/:id(\\d+)'
+    },
+    unamed_params: {
+        path: '/:foo/(.*)'
+    }
+};
+var router;
 
 describe('Router', function () {
     beforeEach(function () {
@@ -149,6 +149,24 @@ describe('Router', function () {
     describe('#getRoute', function () {
         it('existing route', function () {
             var route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html', {method: 'get'});
+            expect(route.name).to.equal('article');
+            expect(route.params.site).to.equal('finance');
+            expect(route.params.category).to.equal('news');
+            expect(route.params.alias).to.equal('e-t-initially-horror-film-202700630.html');
+
+            route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html?query=true', {method: 'get'});
+            expect(route.name).to.equal('article');
+            expect(route.params.site).to.equal('finance');
+            expect(route.params.category).to.equal('news');
+            expect(route.params.alias).to.equal('e-t-initially-horror-film-202700630.html');
+
+            route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html?query=true#hasHashToo', {method: 'get'});
+            expect(route.name).to.equal('article');
+            expect(route.params.site).to.equal('finance');
+            expect(route.params.category).to.equal('news');
+            expect(route.params.alias).to.equal('e-t-initially-horror-film-202700630.html');
+
+            route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html#hasHash', {method: 'get'});
             expect(route.name).to.equal('article');
             expect(route.params.site).to.equal('finance');
             expect(route.params.category).to.equal('news');


### PR DESCRIPTION
@mridgway @redonkulus  @tindli  Finally got time to work on this:
- We have been allowing `path` to contain query string, and even hash fragment when routr runs on client.  Calling it `path` became very confusing.
- Also fixed some coding styles for better readability.
- This is a backward incompatible change.  Will bump minor for the release.
- Will update flux-router-component and flux-examples as well, after this PR.

Fixes https://github.com/yahoo/routr/issues/10
