### PR TITLE
Invalidate match based on navigation type

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -93,7 +93,14 @@ Route.prototype.match = function (url, options) {
         return null;
     }
 
-    // 3. check navParams, if this route has match requirements defined for navParams
+    // 3a. check navigation type
+    if ((options.navigate && options.navigate.type) && self.config.navigate) {
+        if (options.navigate.type !== self.config.navigate.type) {
+            return null;
+        }
+    }
+
+    // 3b. check navParams, if this route has match requirements defined for navParams
     var navParamsConfig = (self.config.navigate && self.config.navigate.params);
     if (navParamsConfig) {
         var navParamConfigKeys = Object.keys(navParamsConfig);


### PR DESCRIPTION
An interesting case come up when two matching paths were not being differentiated when a `navigation.type` was defined.

Take a look at the desired route table:
https://github.com/yahoo/flux-examples/issues/72#issuecomment-69905722