### PR TITLE
remove reverend in favor of path-to-regexp.compile

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -7,7 +7,6 @@
 
 var debug = require('debug')('Routr:router');
 var pathToRegexp = require('path-to-regexp');
-var reverend = require('reverend');
 var METHODS = {
     GET: 'get'
 };
@@ -134,12 +133,28 @@ Route.prototype.match = function (url, options) {
  * @for Route
  */
 Route.prototype.makePath = function (params) {
-    try {
-        return reverend(this.config.path, params);
-    } catch (e) {
-        debug('Route.makePath failed, e = ', e);
-        return null;
+    var route = this.config.path,
+        compiler,
+        err;
+
+    if (Array.isArray(route)) {
+        route = route[0];
     }
+
+    if (typeof route === 'string') {
+        compiler = pathToRegexp.compile(route);
+
+        try {
+            return compiler(params);
+        } catch (e) {
+            err = e;
+        }
+    } else {
+        err = new TypeError('route must be a String path');
+    }
+
+    debug('Route.makePath failed, e = ', err);
+    return null;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   ],
   "dependencies": {
     "debug": "^2.0.0",
-    "path-to-regexp": "^1.0.0",
-    "reverend": "^0.3.0"
+    "path-to-regexp": "^1.1.1"
   },
   "devDependencies": {
     "chai": "^2.0.0",

--- a/tests/unit/lib/router.js
+++ b/tests/unit/lib/router.js
@@ -44,6 +44,12 @@ var routes = {
         path: '/case_insensitive',
         method: 'GET',
         page: 'viewCaseInsensitive'
+    },
+    array_path: {
+        path: ['/array_path']
+    },
+    invalid_path: {
+        path: 123
     }
 };
 var router;
@@ -55,7 +61,7 @@ describe('Router', function () {
 
     describe('#constructor', function () {
         it('should init correctly', function () {
-            expect(Object.keys(router._routes).length).to.equal(7);
+            expect(Object.keys(router._routes).length).to.equal(9);
 
             expect(router._routes.article.name).to.equal('article');
             expect(router._routes.article.config.path).to.equal('/:site/:category?/:subcategory?/:alias');
@@ -98,16 +104,26 @@ describe('Router', function () {
             expect(router._routes.case_insensitive.config.page).to.equal('viewCaseInsensitive');
             expect(router._routes.case_insensitive.keys.length).to.equal(0);
             expect(router._routes.case_insensitive.regexp).to.be.a('RegExp');
+
+            expect(router._routes.array_path.name).to.equal('array_path');
+            expect(router._routes.array_path.config.path[0]).to.equal('/array_path');
+            expect(router._routes.array_path.keys.length).to.equal(0);
+            expect(router._routes.array_path.regexp).to.be.a('RegExp');
+
+            expect(router._routes.invalid_path.name).to.equal('invalid_path');
+            expect(router._routes.invalid_path.config.path).to.equal(123);
+            expect(router._routes.invalid_path.keys.length).to.equal(0);
+            expect(router._routes.invalid_path.regexp).to.be.a('RegExp');
         });
         it('should not freeze in production env', function () {
             var origEnv = process.env.NODE_ENV;
             process.env.NODE_ENV = 'production';
             var notFrozen = new Router(routes);
 
-            expect(Object.keys(notFrozen._routes).length).to.equal(7);
+            expect(Object.keys(notFrozen._routes).length).to.equal(9);
             notFrozen._routes.foo = null;
             expect(notFrozen._routes.foo).to.equal(null);
-            expect(Object.keys(notFrozen._routes).length).to.equal(8);
+            expect(Object.keys(notFrozen._routes).length).to.equal(10);
 
             var homeRoute = notFrozen._routes.home;
             expect(homeRoute.name).to.equal('home');
@@ -120,7 +136,7 @@ describe('Router', function () {
             process.env.NODE_ENV = 'development';
             var frozen = new Router(routes);
             var homeRoute = frozen._routes.home;
-            expect(Object.keys(frozen._routes).length).to.equal(7);
+            expect(Object.keys(frozen._routes).length).to.equal(9);
             expect(homeRoute.name).to.equal('home');
             expect(homeRoute.config.path).to.equal('/');
             expect(homeRoute.config.method).to.equal('get');
@@ -145,7 +161,7 @@ describe('Router', function () {
             expect(function () {
                 homeRoute.config.regexp = null;
             }).to.throw(TypeError);
-            expect(Object.keys(frozen._routes).length).to.equal(7);
+            expect(Object.keys(frozen._routes).length).to.equal(9);
             expect(frozen._routes.foo).to.equal(undefined);
             expect(homeRoute.keys.length).to.equal(0);
             expect(homeRoute.name).to.equal('home');
@@ -287,6 +303,14 @@ describe('Router', function () {
                 subcategory: 'SUBCATEGORY',
                 alias: 'ALIAS.html'
             });
+            expect(path).to.equal(null);
+        });
+        it('array route', function () {
+            var path = router.makePath('array_path', {});
+            expect(path).to.equal('/array_path');
+        });
+        it('invalid route', function () {
+            var path = router.makePath('invalid_path', {});
             expect(path).to.equal(null);
         });
     });


### PR DESCRIPTION
[Path-to-regexp], which powers [Reverend], has recently added the [ability to reverse routes](https://github.com/pillarjs/path-to-regexp#compile-reverse-path-to-regexp), rendering `Reverend` unnecessary. As such, `Reverend` is in the process of being deprecated.

The sole differences between the implementation in `Reverend` and that of `path-to-regexp` is a bit of duck-typing to prevent throws. This small amount of duck-typing can be seen in the [shim](http://github.com/krakenjs/reverend/blob/shim/index.js) branch.

I've duplicated the logic from `Reverend` here however, if it is unnecessary, it can be removed to simplify the code.

[path-to-regexp]: https://github.com/pillarjs/path-to-regexp
[reverend]: https://github.com/krakenjs/reverend