### PR TITLE
Remove navigate.

### DIFF
--- a/docs/routr.md
+++ b/docs/routr.md
@@ -10,14 +10,11 @@ Creates a new routr plugin instance with the following parameters:
 
 ### getRoute(url, options)
 
-Returns the matched route info if path/method/navigate.params matches to a route; null otherwise.
+Returns the matched route info if path/method matches to a route; null otherwise.
 
  * `url` (required) The url to be used for route matching.  Query strings are **not** considered when performing the match.
  * `options` options object
  * `options.method` (optional) The case-insensitive HTTP method string. DEFAULT: 'get'
- * `options.navigate` (required) The navigation info.
- * `options.navigate.type` (required) The navigation type: 'pageload', 'click', 'popstate'.
- * `options.navigate.params` (optional) The navigation params (that are not part of the path).
 
 ### makePath(name, params)
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -46,9 +46,6 @@ Route.prototype.acceptMethod = function (method) {
  *                       would match to the same route as /some_path
  * @param {Object} [options]
  * @param {String} [options.method=get] The case-insensitive HTTP method string.  Defaults to 'get'.
- * @param {Object} [options.navigate] The navigation info.
- * @param {Object} [options.navigate.type] The navigation type: 'pageload', 'click', 'popstate'.
- * @param {Object} [options.navigate.params] The navigation params (that are not part of the path).
  * @return {Object|null} The matched route params if path/method/navParams matches to this route; null otherwise.
  * @for Route
  */
@@ -93,31 +90,7 @@ Route.prototype.match = function (url, options) {
         return null;
     }
 
-    // 3. check navParams, if this route has match requirements defined for navParams
-    var navParamsConfig = (self.config.navigate && self.config.navigate.params);
-    if (navParamsConfig) {
-        var navParamConfigKeys = Object.keys(navParamsConfig);
-        var navParams = (options.navigate && options.navigate.params) || {};
-        var navParamMatched;
-
-        for (i = 0, len = navParamConfigKeys.length; i < len; i++) {
-            // for each navParam defined in the route config, make sure
-            // the param passed in matches the defined pattern
-            var configKey = navParamConfigKeys[i];
-            var pattern = navParamsConfig[configKey];
-            if (pattern instanceof RegExp) {
-                navParamMatched = navParams[configKey] !== undefined && pattern.test(navParams[configKey]);
-            } else {
-                navParamMatched = (navParams[configKey] === pattern);
-            }
-            if (!navParamMatched) {
-                // found a non-matching navParam -> this route does not match
-                return null;
-            }
-        }
-    }
-
-    // 4. method/path/navParams all matched, extract the matched path params
+    // 3. method/path/navParams all matched, extract the matched path params
     var routeParams = {};
     for (i = 0, len = self.keys.length; i < len; i++) {
         // Don't overwrite a previously populated parameter with `undefined`.
@@ -223,10 +196,7 @@ function Router(routes) {
  *                        as /some_path
  * @param {Object} [options]
  * @param {String} [options.method=get] The case-insensitive HTTP method string.
- * @param {Object} [options.navigate] The navigation info.
- * @param {Object} [options.navigate.type] The navigation type: 'pageload', 'click', 'popstate'.
- * @param {Object} [options.navigate.params] The navigation params (that are not part of the path).
- * @return {Object|null} The matched route info if path/method/navigate.params matches to a route; null otherwise.
+ * @return {Object|null} The matched route info if path/method matches to a route; null otherwise.
  */
 Router.prototype.getRoute = function (url, options) {
     var keys = Object.keys(this._routes);
@@ -241,8 +211,7 @@ Router.prototype.getRoute = function (url, options) {
                 name: keys[i],
                 url: url,
                 params: match,
-                config: route.config,
-                navigate: options && options.navigate
+                config: route.config
             };
         }
     }

--- a/tests/unit/lib/router.js
+++ b/tests/unit/lib/router.js
@@ -233,25 +233,6 @@ describe('Router', function () {
             expect(route.name).to.equal('case_insensitive');
         });
 
-        it('check navigate.params if defined', function () {
-            var route = router.getRoute('/', {navigate: {params: {id: 'abcd-efg', foo: 'bar'}}});
-            expect(route.name).to.equal('offnetwork_article', 'navigate: {params.id matches regexp, foo === bar');
-            expect(route.navigate).to.eql({params: {id: 'abcd-efg', foo: 'bar'}}, 'navigate: {params.id does not match, foo === bar');
-            route = router.getRoute('/', {navigate: {params: {id: 'abcd-efg', foo: 'baz'}}});
-            expect(route.name).to.equal('home', 'navigate: {params.id matches regexp, foo !== bar');
-            expect(route.navigate).to.eql({params: {id: 'abcd-efg', foo: 'baz'}}, 'navigate: {params.id does not match, foo === bar');
-            route = router.getRoute('/', {navigate: {params: {id: 'abcd-efg'}}});
-            expect(route.name).to.equal('home', 'navigate: {params.id matches regexp, foo is missing');
-            expect(route.navigate).to.eql({params: {id: 'abcd-efg'}}, 'navigate: {params.id does not match, foo === bar');
-            route = router.getRoute('/', {navigate: {params: {id: 'abcd-ef', foo: 'bar'}}});
-            expect(route.name).to.equal('home', 'navigate: {params.id does not match, foo === bar');
-            expect(route.navigate).to.eql({params: {id: 'abcd-ef', foo: 'bar'}}, 'navigate: {params.id does not match, foo === bar');
-            route = router.getRoute('/', {navigate: {params: {id: undefined}}});
-            expect(route.name).to.equal('home', 'navigate.params.id is undefined');
-            route = router.getRoute('/');
-            expect(route.name).to.equal('home');
-        });
-
         it('non-existing route', function () {
             var route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html', {method: 'post'});
             expect(route).to.equal(null);


### PR DESCRIPTION
This is a breaking change.

This was used for edge cases where a url may stay the same but other factors may cause a navigation to happen. Routr should not be taking this into account since it is simply a route matching library. If needed, the navigation logic should happen at a higher level or remove that special case.