### PR TITLE
[resolves #28] Allow array as route definition and document as standard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 sudo: false
 language: node_js
-matrix:
-  allow_failures:
-    - node_js: "0.13"
 node_js:
-  - "iojs"
-  - "0.13"
+  - 5
+  - 4
   - "0.12"
   - "0.10"
 after_success:

--- a/README.md
+++ b/README.md
@@ -16,19 +16,21 @@ For more detailed examples, please check out [example applications](https://gith
 ```javascript
 var Router = require('routr');
 
-var router = new Router({
-    view_user: {
+var router = new Router([
+    {
+        name: 'view_user',
         path: '/user/:id',
         method: 'get',
         foo: {
             bar: 'baz'
         }
     },
-    view_user_post: {
+    {
+        name: 'view_user_post',
         path: '/user/:id/post/:post',
         method: 'get'
     }
-});
+]);
 
 // match route
 var route = router.getRoute('/user/garfield');

--- a/docs/routr.md
+++ b/docs/routr.md
@@ -4,7 +4,11 @@
 
 Creates a new routr plugin instance with the following parameters:
 
- * `routes` (optional): Route table, which is a name to router config map.
+ * `routes` (optional): Ordered list of routes used for matching.
+ ** `route.name`: Name of the route (used for path making)
+ ** `route.path`: The matching pattern of the route. Follows rules of [path-to-regexp](https://github
+ .com/pillarjs/path-to-regexp)
+ ** `route.method=GET`: The method that the path should match to.
 
 ## Instance Methods
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -170,15 +170,32 @@ Route.prototype.makePath = function (params) {
 function Router(routes) {
     var self = this;
     self._routes = {};
+    self._routeOrder = [];
     debug('new Router, routes = ', routes);
-    if (routes) {
-        Object.keys(routes).forEach(function createRoute(name) {
+
+    if (!Array.isArray(routes)) {
+        // Support handling route config object as an ordered map (legacy)
+        self._routeOrder = Object.keys(routes);
+        self._routeOrder.forEach(function createRoute(name) {
             self._routes[name] = new Route(name, routes[name]);
         });
+    } else if (routes) {
+        routes.forEach(function createRouteFromArrayValue(route) {
+            if (!route.name) {
+                throw new Error('Undefined route name for route ' + route.path);
+            }
+            // Route name already exists
+            if (self._routes[route.name]) {
+                throw new Error('Duplicate route with name ' + route.name);
+            }
+            self._routeOrder.push(route.name);
+            self._routes[route.name] = new Route(route.name, route);
+        });
     }
+
     if (process.env.NODE_ENV !== 'production') {
         if ('function' === typeof Object.freeze) {
-            Object.keys(self._routes).forEach(function freezeRoute(name) {
+            self._routeOrder.forEach(function freezeRoute(name) {
                 var route = self._routes[name];
                 Object.freeze(route.config);
                 Object.freeze(route.keys);
@@ -199,7 +216,7 @@ function Router(routes) {
  * @return {Object|null} The matched route info if path/method matches to a route; null otherwise.
  */
 Router.prototype.getRoute = function (url, options) {
-    var keys = Object.keys(this._routes);
+    var keys = this._routeOrder;
     var route;
     var match;
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "cover": "node node_modules/istanbul/lib/cli.js cover --dir artifacts -- ./node_modules/mocha/bin/_mocha tests/unit/ --recursive --reporter spec",
     "lint": "./node_modules/.bin/jshint lib tests",
-    "test": "./node_modules/.bin/mocha tests/unit/ --recursive --reporter spec"
+    "test": "./node_modules/.bin/mocha tests/unit/ --recursive --compilers js:babel-register --require babel-polyfill --reporter spec"
   },
   "author": "Lingyan Zhu <lingyan@yahoo-inc.com",
   "licenses": [
@@ -24,6 +24,9 @@
     "path-to-regexp": "^1.1.1"
   },
   "devDependencies": {
+    "babel-polyfill": "^6.7.2",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-register": "^6.7.2",
     "chai": "^2.0.0",
     "coveralls": "^2.11.1",
     "istanbul": "^0.3.2",

--- a/tests/.babelrc
+++ b/tests/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["es2015"],
+    "plugins": []
+}

--- a/tests/unit/lib/router.js
+++ b/tests/unit/lib/router.js
@@ -7,7 +7,7 @@
 
 var expect = require('chai').expect;
 var Router = require('../../../lib/router');
-var routes = {
+var routesObject = {
     article: {
         path: '/:site/:category?/:subcategory?/:alias',
         method: 'get',
@@ -60,263 +60,298 @@ var routes = {
         path: 123
     }
 };
+var routesArray = Object.keys(routesObject).map(function (routeName) {
+    return Object.assign({}, routesObject[routeName], {
+        name: routeName
+    });
+});
 var router;
 
 describe('Router', function () {
-    beforeEach(function () {
-        router = new Router(routes);
+    var text = ['routes object', 'routes array'];
+    [routesObject, routesArray].forEach(function (routes, key) {
+        describe(text[key], function () {
+            beforeEach(function () {
+                router = new Router(routes);
+            });
+
+            describe('#constructor', function () {
+                it('should init correctly', function () {
+                    expect(Object.keys(router._routes).length).to.equal(10);
+
+                    expect(router._routes.article.name).to.equal('article');
+                    expect(router._routes.article.config.path).to.equal('/:site/:category?/:subcategory?/:alias');
+                    expect(router._routes.article.config.method).to.equal('get');
+                    expect(router._routes.article.config.page).to.equal('viewArticle');
+                    expect(router._routes.article.config.navigate).to.equal(undefined);
+                    expect(router._routes.article.keys.length).to.equal(4);
+                    expect(router._routes.article.keys[0].name).to.equal('site');
+                    expect(router._routes.article.keys[1].name).to.equal('category');
+                    expect(router._routes.article.keys[2].name).to.equal('subcategory');
+                    expect(router._routes.article.keys[3].name).to.equal('alias');
+                    expect(router._routes.article.regexp).to.be.a('RegExp');
+
+                    expect(router._routes.offnetwork_article.name).to.equal('offnetwork_article');
+                    expect(router._routes.offnetwork_article.config.path).to.equal('/');
+                    expect(router._routes.offnetwork_article.config.method).to.equal('get');
+                    expect(router._routes.offnetwork_article.config.page).to.equal('viewArticle');
+                    expect(router._routes.offnetwork_article.config.navigate.params).to.be.a('object');
+                    expect(router._routes.offnetwork_article.config.navigate.params.id).to.be.a('RegExp');
+                    expect(router._routes.offnetwork_article.keys.length).to.equal(0);
+                    expect(router._routes.offnetwork_article.regexp).to.be.a('RegExp');
+
+                    expect(router._routes.home.name).to.equal('home');
+                    expect(router._routes.home.config.path).to.equal('/');
+                    expect(router._routes.home.config.method).to.equal('get');
+                    expect(router._routes.home.config.page).to.equal('viewHomepage');
+                    expect(router._routes.home.keys.length).to.equal(0);
+                    expect(router._routes.home.regexp).to.be.a('RegExp');
+
+                    expect(router._routes.new_article.name).to.equal('new_article');
+                    expect(router._routes.new_article.config.path).to.equal('/new_article');
+                    expect(router._routes.new_article.config.method).to.equal('post');
+                    expect(router._routes.new_article.config.page).to.equal('createArticle');
+                    expect(router._routes.new_article.keys.length).to.equal(0);
+                    expect(router._routes.new_article.regexp).to.be.a('RegExp');
+
+                    expect(router._routes.case_insensitive.name).to.equal('case_insensitive');
+                    expect(router._routes.case_insensitive.config.path).to.equal('/case_insensitive');
+                    expect(router._routes.case_insensitive.config.method).to.equal('GET');
+                    expect(router._routes.case_insensitive.config.page).to.equal('viewCaseInsensitive');
+                    expect(router._routes.case_insensitive.keys.length).to.equal(0);
+                    expect(router._routes.case_insensitive.regexp).to.be.a('RegExp');
+
+                    expect(router._routes.array_path.name).to.equal('array_path');
+                    expect(router._routes.array_path.config.path[0]).to.equal('/array_path');
+                    expect(router._routes.array_path.keys.length).to.equal(0);
+                    expect(router._routes.array_path.regexp).to.be.a('RegExp');
+
+                    expect(router._routes.invalid_path.name).to.equal('invalid_path');
+                    expect(router._routes.invalid_path.config.path).to.equal(123);
+                    expect(router._routes.invalid_path.keys.length).to.equal(0);
+                    expect(router._routes.invalid_path.regexp).to.be.a('RegExp');
+                });
+                it('should not freeze in production env', function () {
+                    var origEnv = process.env.NODE_ENV;
+                    process.env.NODE_ENV = 'production';
+                    var notFrozen = new Router(routes);
+
+                    expect(Object.keys(notFrozen._routes).length).to.equal(10);
+                    notFrozen._routes.foo = null;
+                    expect(notFrozen._routes.foo).to.equal(null);
+                    expect(Object.keys(notFrozen._routes).length).to.equal(11);
+
+                    var homeRoute = notFrozen._routes.home;
+                    expect(homeRoute.name).to.equal('home');
+                    homeRoute.name = 'changed';
+                    expect(homeRoute.name).to.equal('changed');
+                    process.env.NODE_ENV = origEnv;
+                });
+                it('should freeze in non-production env', function () {
+                    var origEnv = process.env.NODE_ENV;
+                    process.env.NODE_ENV = 'development';
+                    var frozen = new Router(routes);
+                    var homeRoute = frozen._routes.home;
+                    expect(Object.keys(frozen._routes).length).to.equal(10);
+                    expect(homeRoute.name).to.equal('home');
+                    expect(homeRoute.config.path).to.equal('/');
+                    expect(homeRoute.config.method).to.equal('get');
+                    expect(homeRoute.config.page).to.equal('viewHomepage');
+                    expect(homeRoute.keys.length).to.equal(0);
+                    expect(homeRoute.regexp).to.be.a('RegExp');
+                    expect(function () {
+                        frozen._routes.foo = 'abc';
+                    }).to.throw(TypeError);
+                    expect(function () {
+                        homeRoute.name = 'unfreeze!';
+                    }).to.throw(TypeError);
+                    expect(function () {
+                        homeRoute.config.method = 'unfreeze!';
+                    }).to.throw(TypeError);
+                    expect(function () {
+                        homeRoute.config.page = 'unfreeze!';
+                    }).to.throw(TypeError);
+                    expect(function () {
+                        homeRoute.keys[0] = 'unfreeze!';
+                    }).to.throw(TypeError);
+                    expect(function () {
+                        homeRoute.config.regexp = null;
+                    }).to.throw(TypeError);
+                    expect(Object.keys(frozen._routes).length).to.equal(10);
+                    expect(frozen._routes.foo).to.equal(undefined);
+                    expect(homeRoute.keys.length).to.equal(0);
+                    expect(homeRoute.name).to.equal('home');
+                    expect(homeRoute.config.path).to.equal('/');
+                    expect(homeRoute.config.method).to.equal('get');
+                    expect(homeRoute.config.page).to.equal('viewHomepage');
+                    expect(homeRoute.keys.length).to.equal(0);
+                    expect(homeRoute.regexp).to.be.a('RegExp');
+                    process.env.NODE_ENV = origEnv;
+                });
+            });
+
+            describe('#getRoute', function () {
+                it('existing route', function () {
+                    var route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html', {method: 'get'});
+                    expect(route.name).to.equal('article');
+                    expect(route.params.site).to.equal('finance');
+                    expect(route.params.category).to.equal('news');
+                    expect(route.params.alias).to.equal('e-t-initially-horror-film-202700630.html');
+
+                    route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html?query=true', {method: 'get'});
+                    expect(route.name).to.equal('article');
+                    expect(route.params.site).to.equal('finance');
+                    expect(route.params.category).to.equal('news');
+                    expect(route.params.alias).to.equal('e-t-initially-horror-film-202700630.html');
+
+                    route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html?query=true#hasHashToo', {method: 'get'});
+                    expect(route.name).to.equal('article');
+                    expect(route.params.site).to.equal('finance');
+                    expect(route.params.category).to.equal('news');
+                    expect(route.params.alias).to.equal('e-t-initially-horror-film-202700630.html');
+
+                    route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html#hasHash', {method: 'get'});
+                    expect(route.name).to.equal('article');
+                    expect(route.params.site).to.equal('finance');
+                    expect(route.params.category).to.equal('news');
+                    expect(route.params.alias).to.equal('e-t-initially-horror-film-202700630.html');
+
+                    route = router.getRoute('/sports/blogs/nfl-shutdown-corner/report-says-aaron-hernandez-having-trouble-paying-legal-bills-215349137.html', {method: 'get'});
+                    expect(route.name).to.equal('article');
+                    expect(route.params.site).to.equal('sports');
+                    expect(route.params.category).to.equal('blogs');
+                    expect(route.params.subcategory).to.equal('nfl-shutdown-corner');
+                    expect(route.params.alias).to.equal('report-says-aaron-hernandez-having-trouble-paying-legal-bills-215349137.html');
+
+                    route = router.getRoute('/new_article', {method: 'post'});
+                    expect(route.name).to.equal('new_article');
+
+                    route = router.getRoute('/new_article?foo=bar', {method: 'post'});
+                    expect(route.name).to.equal('new_article');
+                });
+
+                it('method should be case-insensitive and defaults to get', function () {
+                    var route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html');
+                    expect(route.name).to.equal('article');
+                    route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html', {method: 'GET'});
+                    expect(route.name).to.equal('article');
+                    route = router.getRoute('/new_article', {method: 'POST'});
+                    expect(route.name).to.equal('new_article');
+                    route = router.getRoute('/case_insensitive', {method: 'get'});
+                    expect(route.name).to.equal('case_insensitive');
+                });
+
+                it('non-existing route', function () {
+                    var route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html', {method: 'post'});
+                    expect(route).to.equal(null);
+
+                    route = router.getRoute('/finance');
+                    expect(route).to.equal(null);
+
+                    route = router.getRoute('/new_article', 'delete');
+                    expect(route).to.equal(null);
+                });
+                it('array route with param name collision first', function () {
+                    var route = router.getRoute('/array/path/with/collision/foo/abc');
+                    expect(route.params.key).to.equal('abc');
+                });
+                it('array route with param name collision second', function () {
+                    var route = router.getRoute('/array/path/with/collision/bar/abc');
+                    expect(route.params.key).to.equal('abc');
+                });
+
+            });
+
+            describe('#makePath', function () {
+                it('existing route', function () {
+                    var path = router.makePath('article', {
+                        site: 'SITE',
+                        category: 'CATEGORY',
+                        subcategory: 'SUBCATEGORY',
+                        alias: 'ALIAS.html'
+                    });
+                    expect(path).to.equal('/SITE/CATEGORY/SUBCATEGORY/ALIAS.html');
+                });
+                it('handle optional params', function () {
+                    var path = router.makePath('article', {
+                        site: 'SITE',
+                        category: 'CATEGORY',
+                        alias: 'ALIAS.html'
+                    });
+                    expect(path).to.equal('/SITE/CATEGORY/ALIAS.html');
+                    path = router.makePath('article', {
+                        site: 'SITE',
+                        alias: 'ALIAS.html'
+                    });
+                    expect(path).to.equal('/SITE/ALIAS.html');
+                });
+                it('handle custom match params', function () {
+                    var path = router.makePath('custom_match_params', {
+                        id: '12345'
+                    });
+                    expect(path).to.equal('/posts/12345');
+                    path = router.makePath('custom_match_params', {
+                        id: '12345abc'
+                    });
+                    expect(path).to.equal(null);
+                });
+                it('handle unamed params', function () {
+                    var path = router.makePath('unamed_params', {
+                        foo: 'foo',
+                        0: 'bar'
+                    });
+                    expect(path).to.equal('/foo/bar');
+                });
+                it('non-existing route', function () {
+                    var path = router.makePath('article_does_not_exist', {
+                        site: 'SITE',
+                        category: 'CATEGORY',
+                        subcategory: 'SUBCATEGORY',
+                        alias: 'ALIAS.html'
+                    });
+                    expect(path).to.equal(null);
+                });
+                it('array route', function () {
+                    var path = router.makePath('array_path', {});
+                    expect(path).to.equal('/array_path');
+                });
+                it('invalid route', function () {
+                    var path = router.makePath('invalid_path', {});
+                    expect(path).to.equal(null);
+                });
+            });
+        });
     });
 
-    describe('#constructor', function () {
-        it('should init correctly', function () {
-            expect(Object.keys(router._routes).length).to.equal(10);
-
-            expect(router._routes.article.name).to.equal('article');
-            expect(router._routes.article.config.path).to.equal('/:site/:category?/:subcategory?/:alias');
-            expect(router._routes.article.config.method).to.equal('get');
-            expect(router._routes.article.config.page).to.equal('viewArticle');
-            expect(router._routes.article.config.navigate).to.equal(undefined);
-            expect(router._routes.article.keys.length).to.equal(4);
-            expect(router._routes.article.keys[0].name).to.equal('site');
-            expect(router._routes.article.keys[1].name).to.equal('category');
-            expect(router._routes.article.keys[2].name).to.equal('subcategory');
-            expect(router._routes.article.keys[3].name).to.equal('alias');
-            expect(router._routes.article.regexp).to.be.a('RegExp');
-
-            expect(router._routes.offnetwork_article.name).to.equal('offnetwork_article');
-            expect(router._routes.offnetwork_article.config.path).to.equal('/');
-            expect(router._routes.offnetwork_article.config.method).to.equal('get');
-            expect(router._routes.offnetwork_article.config.page).to.equal('viewArticle');
-            expect(router._routes.offnetwork_article.config.navigate.params).to.be.a('object');
-            expect(router._routes.offnetwork_article.config.navigate.params.id).to.be.a('RegExp');
-            expect(router._routes.offnetwork_article.keys.length).to.equal(0);
-            expect(router._routes.offnetwork_article.regexp).to.be.a('RegExp');
-
-            expect(router._routes.home.name).to.equal('home');
-            expect(router._routes.home.config.path).to.equal('/');
-            expect(router._routes.home.config.method).to.equal('get');
-            expect(router._routes.home.config.page).to.equal('viewHomepage');
-            expect(router._routes.home.keys.length).to.equal(0);
-            expect(router._routes.home.regexp).to.be.a('RegExp');
-
-            expect(router._routes.new_article.name).to.equal('new_article');
-            expect(router._routes.new_article.config.path).to.equal('/new_article');
-            expect(router._routes.new_article.config.method).to.equal('post');
-            expect(router._routes.new_article.config.page).to.equal('createArticle');
-            expect(router._routes.new_article.keys.length).to.equal(0);
-            expect(router._routes.new_article.regexp).to.be.a('RegExp');
-
-            expect(router._routes.case_insensitive.name).to.equal('case_insensitive');
-            expect(router._routes.case_insensitive.config.path).to.equal('/case_insensitive');
-            expect(router._routes.case_insensitive.config.method).to.equal('GET');
-            expect(router._routes.case_insensitive.config.page).to.equal('viewCaseInsensitive');
-            expect(router._routes.case_insensitive.keys.length).to.equal(0);
-            expect(router._routes.case_insensitive.regexp).to.be.a('RegExp');
-
-            expect(router._routes.array_path.name).to.equal('array_path');
-            expect(router._routes.array_path.config.path[0]).to.equal('/array_path');
-            expect(router._routes.array_path.keys.length).to.equal(0);
-            expect(router._routes.array_path.regexp).to.be.a('RegExp');
-
-            expect(router._routes.invalid_path.name).to.equal('invalid_path');
-            expect(router._routes.invalid_path.config.path).to.equal(123);
-            expect(router._routes.invalid_path.keys.length).to.equal(0);
-            expect(router._routes.invalid_path.regexp).to.be.a('RegExp');
-        });
-        it('should not freeze in production env', function () {
-            var origEnv = process.env.NODE_ENV;
-            process.env.NODE_ENV = 'production';
-            var notFrozen = new Router(routes);
-
-            expect(Object.keys(notFrozen._routes).length).to.equal(10);
-            notFrozen._routes.foo = null;
-            expect(notFrozen._routes.foo).to.equal(null);
-            expect(Object.keys(notFrozen._routes).length).to.equal(11);
-
-            var homeRoute = notFrozen._routes.home;
-            expect(homeRoute.name).to.equal('home');
-            homeRoute.name = 'changed';
-            expect(homeRoute.name).to.equal('changed');
-            process.env.NODE_ENV = origEnv;
-        });
-        it('should freeze in non-production env', function () {
-            var origEnv = process.env.NODE_ENV;
-            process.env.NODE_ENV = 'development';
-            var frozen = new Router(routes);
-            var homeRoute = frozen._routes.home;
-            expect(Object.keys(frozen._routes).length).to.equal(10);
-            expect(homeRoute.name).to.equal('home');
-            expect(homeRoute.config.path).to.equal('/');
-            expect(homeRoute.config.method).to.equal('get');
-            expect(homeRoute.config.page).to.equal('viewHomepage');
-            expect(homeRoute.keys.length).to.equal(0);
-            expect(homeRoute.regexp).to.be.a('RegExp');
-            expect(function () {
-                frozen._routes.foo = 'abc';
-            }).to.throw(TypeError);
-            expect(function () {
-                homeRoute.name = 'unfreeze!';
-            }).to.throw(TypeError);
-            expect(function () {
-                homeRoute.config.method = 'unfreeze!';
-            }).to.throw(TypeError);
-            expect(function () {
-                homeRoute.config.page = 'unfreeze!';
-            }).to.throw(TypeError);
-            expect(function () {
-                homeRoute.keys[0] = 'unfreeze!';
-            }).to.throw(TypeError);
-            expect(function () {
-                homeRoute.config.regexp = null;
-            }).to.throw(TypeError);
-            expect(Object.keys(frozen._routes).length).to.equal(10);
-            expect(frozen._routes.foo).to.equal(undefined);
-            expect(homeRoute.keys.length).to.equal(0);
-            expect(homeRoute.name).to.equal('home');
-            expect(homeRoute.config.path).to.equal('/');
-            expect(homeRoute.config.method).to.equal('get');
-            expect(homeRoute.config.page).to.equal('viewHomepage');
-            expect(homeRoute.keys.length).to.equal(0);
-            expect(homeRoute.regexp).to.be.a('RegExp');
-            process.env.NODE_ENV = origEnv;
-        });
+    it('should throw if route name is not defined', function () {
+        expect(function () {
+            new Router([
+                {
+                    path: '/'
+                }
+            ]);
+        }).to.throw(Error);
     });
 
-    describe('#getRoute', function () {
-        it('existing route', function () {
-            var route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html', {method: 'get'});
-            expect(route.name).to.equal('article');
-            expect(route.params.site).to.equal('finance');
-            expect(route.params.category).to.equal('news');
-            expect(route.params.alias).to.equal('e-t-initially-horror-film-202700630.html');
-
-            route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html?query=true', {method: 'get'});
-            expect(route.name).to.equal('article');
-            expect(route.params.site).to.equal('finance');
-            expect(route.params.category).to.equal('news');
-            expect(route.params.alias).to.equal('e-t-initially-horror-film-202700630.html');
-
-            route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html?query=true#hasHashToo', {method: 'get'});
-            expect(route.name).to.equal('article');
-            expect(route.params.site).to.equal('finance');
-            expect(route.params.category).to.equal('news');
-            expect(route.params.alias).to.equal('e-t-initially-horror-film-202700630.html');
-
-            route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html#hasHash', {method: 'get'});
-            expect(route.name).to.equal('article');
-            expect(route.params.site).to.equal('finance');
-            expect(route.params.category).to.equal('news');
-            expect(route.params.alias).to.equal('e-t-initially-horror-film-202700630.html');
-
-            route = router.getRoute('/sports/blogs/nfl-shutdown-corner/report-says-aaron-hernandez-having-trouble-paying-legal-bills-215349137.html', {method: 'get'});
-            expect(route.name).to.equal('article');
-            expect(route.params.site).to.equal('sports');
-            expect(route.params.category).to.equal('blogs');
-            expect(route.params.subcategory).to.equal('nfl-shutdown-corner');
-            expect(route.params.alias).to.equal('report-says-aaron-hernandez-having-trouble-paying-legal-bills-215349137.html');
-
-            route = router.getRoute('/new_article', {method: 'post'});
-            expect(route.name).to.equal('new_article');
-
-            route = router.getRoute('/new_article?foo=bar', {method: 'post'});
-            expect(route.name).to.equal('new_article');
-        });
-
-        it('method should be case-insensitive and defaults to get', function () {
-            var route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html');
-            expect(route.name).to.equal('article');
-            route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html', {method: 'GET'});
-            expect(route.name).to.equal('article');
-            route = router.getRoute('/new_article', {method: 'POST'});
-            expect(route.name).to.equal('new_article');
-            route = router.getRoute('/case_insensitive', {method: 'get'});
-            expect(route.name).to.equal('case_insensitive');
-        });
-
-        it('non-existing route', function () {
-            var route = router.getRoute('/finance/news/e-t-initially-horror-film-202700630.html', {method: 'post'});
-            expect(route).to.equal(null);
-
-            route = router.getRoute('/finance');
-            expect(route).to.equal(null);
-
-            route = router.getRoute('/new_article', 'delete');
-            expect(route).to.equal(null);
-        });
-        it('array route with param name collision first', function () {
-            var route = router.getRoute('/array/path/with/collision/foo/abc');
-            expect(route.params.key).to.equal('abc');
-        });
-        it('array route with param name collision second', function () {
-            var route = router.getRoute('/array/path/with/collision/bar/abc');
-            expect(route.params.key).to.equal('abc');
-        });
-
-    });
-
-    describe('#makePath', function () {
-        it('existing route', function () {
-            var path = router.makePath('article', {
-                site: 'SITE',
-                category: 'CATEGORY',
-                subcategory: 'SUBCATEGORY',
-                alias: 'ALIAS.html'
-            });
-            expect(path).to.equal('/SITE/CATEGORY/SUBCATEGORY/ALIAS.html');
-        });
-        it('handle optional params', function () {
-            var path = router.makePath('article', {
-                site: 'SITE',
-                category: 'CATEGORY',
-                alias: 'ALIAS.html'
-            });
-            expect(path).to.equal('/SITE/CATEGORY/ALIAS.html');
-            path = router.makePath('article', {
-                site: 'SITE',
-                alias: 'ALIAS.html'
-            });
-            expect(path).to.equal('/SITE/ALIAS.html');
-        });
-        it('handle custom match params', function () {
-            var path = router.makePath('custom_match_params', {
-                id: '12345'
-            });
-            expect(path).to.equal('/posts/12345');
-            path = router.makePath('custom_match_params', {
-                id: '12345abc'
-            });
-            expect(path).to.equal(null);
-        });
-        it('handle unamed params', function () {
-            var path = router.makePath('unamed_params', {
-                foo: 'foo',
-                0: 'bar'
-            });
-            expect(path).to.equal('/foo/bar');
-        });
-        it('non-existing route', function () {
-            var path = router.makePath('article_does_not_exist', {
-                site: 'SITE',
-                category: 'CATEGORY',
-                subcategory: 'SUBCATEGORY',
-                alias: 'ALIAS.html'
-            });
-            expect(path).to.equal(null);
-        });
-        it('array route', function () {
-            var path = router.makePath('array_path', {});
-            expect(path).to.equal('/array_path');
-        });
-        it('invalid route', function () {
-            var path = router.makePath('invalid_path', {});
-            expect(path).to.equal(null);
-        });
+    it('should throw if there are routes with duplicate name', function () {
+        expect(function () {
+            new Router([
+                {
+                    name: 'home',
+                    path: '/'
+                },
+                {
+                    name: 'home',
+                    path: '/home'
+                }
+            ]);
+        }).to.throw(Error);
     });
 });
 
 describe('Route', function () {
     it('match', function () {
-        router = new Router(routes);
+        router = new Router(routesObject);
         var homeRoute = router._routes.home;
         expect(homeRoute.match()).to.equal(null, 'empty path returns null');
     });


### PR DESCRIPTION
This does not break that compatibility with object definitions, but does remove documentation for it since array is more clear on the order of routes.