### PR TITLE
Fix encoding/decoding inconsistency when using values that need scaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,25 @@
 # Change Log
 
+## 2.0.0
+
+### Breaking Changes
+
+ * [#33] `getRoute` will now `decodeURIComponent` route values, you might need to remove `decodeURIComponent` from your route actions if you were supporting extended characters manually in your routes.
+
 ## 1.0.0
 
 ### Breaking Changes
 
  * [#29] `navigate` is no longer used as part of `router.getRoute` options
  * [#29] `route.navigate` has been removed from the matched route object
- 
+
 ### Features
 
- * [#30] Route definitions should now be defined as an array of route objects 
+ * [#30] Route definitions should now be defined as an array of route objects
  rather than a map of routes. The old method of defining routes with a map
  is still supported, but ordering can not be guaranteed (as per the JavaScript
  engine's implementation).
- * [#31] Added support for parsing and constructing urls with query strings. 
+ * [#31] Added support for parsing and constructing urls with query strings.
  Matched route objects now contain a `query` property containing the map of
  query parameters. `router.makePath` now accepts a third `query` parameter
  which is a map of query parameters to add to the resulting URL string. e.g.

--- a/lib/router.js
+++ b/lib/router.js
@@ -119,7 +119,9 @@ Route.prototype.match = function (url, options) {
         // A route may legitimately have multiple instances of a parameter
         // name if the path was an array.
         if (pathMatches[i+1] !== undefined || routeParams[self.keys[i].name] === undefined){
-            routeParams[self.keys[i].name] = pathMatches[i+1];
+            // Because pathToRegexp encodeURIComponent params values, it is necessary
+            // to decode when reading from URL
+            routeParams[self.keys[i].name] = decodeURIComponent(pathMatches[i+1]);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "routr",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A router for both server and client",
   "main": "index.js",
   "repository": {

--- a/tests/unit/lib/router.js
+++ b/tests/unit/lib/router.js
@@ -71,6 +71,9 @@ var routesObject = {
     },
     invalid_path: {
         path: 123
+    },
+    json_value: {
+        path: '/path/with/some/json_value/:json'
     }
 };
 var routesArray = Object.keys(routesObject).map(function (routeName) {
@@ -78,6 +81,7 @@ var routesArray = Object.keys(routesObject).map(function (routeName) {
         name: routeName
     });
 });
+var encodingConsistencyPath = '/path/with/some/json_value/%7B%22keyword%22%3A%22foo%22%7D';
 
 describe('Router', function () {
     [routesObject, routesArray].forEach(function (routes, key) {
@@ -284,6 +288,10 @@ describe('Router', function () {
             var route = router.getRoute('/array/path/with/collision/bar/abc');
             expect(route.params.key).to.equal('abc');
         });
+        it('route with json string in param with consistency', function () {
+            var route = router.getRoute(encodingConsistencyPath);
+            expect(route.params.json).to.equal('{"keyword":"foo"}');
+        });
 
         it('should allow route to match multiple methods', function () {
             var route = 'multi_methods';
@@ -380,6 +388,12 @@ describe('Router', function () {
         it('invalid route', function () {
             var path = router.makePath('invalid_path', {});
             expect(path).to.equal(null);
+        });
+        it('path with some json value and consistency', function () {
+            var path = router.makePath('json_value', {
+                json: JSON.stringify({keyword: 'foo'})
+            });
+            expect(path).to.equal(encodingConsistencyPath);
         });
     });
 


### PR DESCRIPTION
Since `makePath` uses `pathToRegexp` which in place uses `encodeURIComponent` for all values, when getRoute tries to match a URL generated by the router itself, it returns a double enconded value.

I suspect this is the root cause for fluxible-router to avoid using parsed URLs and [bookeeping the origURL instead](1).

I added tests to both `match` (indirectly through `getRoute`) and to `makePath`. Notice that if you comment or remove `decodeURIComponent` from the implementation, only 1 of the tests fails. This proves the undesired inconsistency.

I do hate JSON in URLs and I know it is a bad practice, and I do want to remove this from the application I am working on (nope, I didn't introduce in the first place). But I believe this to be beneficial to the router... who does not want to support `/emoji/😍/used/in/paths`?

@mridgway 

[1]: https://github.com/yahoo/fluxible/blob/2be37f6df6ef5d5ed7c31fae5ec14843f924b213/packages/fluxible-router/lib/History.js#L66-L73