### PR TITLE
Only append query if there is something to append

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -149,6 +149,7 @@ Route.prototype.makePath = function (params, query) {
     var compiler;
     var err;
     var url;
+    var strQuery;
 
     if (Array.isArray(routePath)) {
         routePath = routePath[0];
@@ -161,7 +162,10 @@ Route.prototype.makePath = function (params, query) {
         try {
             url = compiler(params);
             if (query) {
-                url += '?' + this._queryLib.stringify(query);
+                strQuery = this._queryLib.stringify(query);
+                if (strQuery) {
+                    url += '?' + strQuery;
+                }
             }
             return url;
         } catch (e) {

--- a/tests/unit/lib/router.js
+++ b/tests/unit/lib/router.js
@@ -364,6 +364,13 @@ describe('Router', function () {
             });
             expect(path).to.equal('/foo/bar?baz=foo&foo=bar');
         });
+        it('adds no question mark with empty query', function () {
+            var path = router.makePath('unamed_params', {
+                foo: 'foo',
+                0: 'bar'
+            }, {/* empty object */});
+            expect(path).to.equal('/foo/bar');
+        });
         it('non-existing route', function () {
             var path = router.makePath('article_does_not_exist', {
                 site: 'SITE',


### PR DESCRIPTION
This is mostly cosmetic, but it is really strange to have a question
mark if you don't have query, and adding checks on any application
using routr seems wasteful.

i.e. in my application I use: `Object.assing({}, detaultQuery, myFuncQueryParam)` and sometimes I get an empty object. It would be convenient if the router didn't add the question mark.

    r.makePath('my', {wat:'route'}, {});

Before this patch: /my/route?
After this patch: /my/route