### PR TITLE
Fix decodeURIComponent of undefined bug

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -118,7 +118,7 @@ Route.prototype.match = function (url, options) {
         // Don't overwrite a previously populated parameter with `undefined`.
         // A route may legitimately have multiple instances of a parameter
         // name if the path was an array.
-        if (pathMatches[i+1] !== undefined || routeParams[self.keys[i].name] === undefined){
+        if (pathMatches[i+1] !== undefined && routeParams[self.keys[i].name] === undefined){
             // Because pathToRegexp encodeURIComponent params values, it is necessary
             // to decode when reading from URL
             routeParams[self.keys[i].name] = decodeURIComponent(pathMatches[i+1]);

--- a/tests/unit/lib/router.js
+++ b/tests/unit/lib/router.js
@@ -474,5 +474,12 @@ describe('Route', function () {
         var homeRoute = router._routes.home;
         expect(homeRoute.match()).to.equal(null, 'empty path returns null');
     });
+    it('should leave unset optional parameters as undefined', function(){
+        var router = new Router(routesObject);
+        var article = router._routes.article;
+        var result = article.match('/site/alias');
+        expect(result.route.category).to.be.undefined;
+        expect(result.route.subcategory).to.be.undefined;
+    });
 });
 


### PR DESCRIPTION
decodeURIComponent(undefined) returns 'undefined' which sets
all optional parameters that are not present in the url to the
string value 'undefined'.