### PR TITLE
Add support for question marks in hash fragments

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -90,22 +90,20 @@ Route.prototype.match = function (url, options) {
 
     // 2. check path
     // remove query string and hash fragment from url
-    var pos = url.indexOf('?');
-    var path;
-    if (pos >= 0) {
-        // remove query string
-        path = url.substring(0, pos);
-    } else {
-        pos = url.indexOf('#');
+    //
+    // hash fragment does not get sent to server.
+    // But since routr can be used on both server and client,
+    // we should remove hash fragment before matching the regex.
+    var path = url;
+    var pos;
+
+    // Leave `pos` at the beginning of the query-string, if any.
+    ['#', '?'].forEach(function(delimiter){
+        pos = url.indexOf(delimiter);
         if (pos >= 0) {
-            // hash fragment does not get sent to server.
-            // But since routr can be used on both server and client,
-            // we should remove hash fragment before matching the regex.
-            path = url.substring(0, pos);
-        } else {
-            path = url;
+            path = path.substring(0, pos);
         }
-    }
+    });
 
     var pathMatches = self.regexp.exec(path);
     if (!pathMatches) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -99,7 +99,7 @@ Route.prototype.match = function (url, options) {
 
     // Leave `pos` at the beginning of the query-string, if any.
     ['#', '?'].forEach(function(delimiter){
-        pos = url.indexOf(delimiter);
+        pos = path.indexOf(delimiter);
         if (pos >= 0) {
             path = path.substring(0, pos);
         }

--- a/tests/unit/lib/router.js
+++ b/tests/unit/lib/router.js
@@ -292,6 +292,13 @@ describe('Router', function () {
             var route = router.getRoute(encodingConsistencyPath);
             expect(route.params.json).to.equal('{"keyword":"foo"}');
         });
+        it('should handle a hash fragment with a question-mark', function () {
+            var route = router.getRoute('/finance/news/test.html#?', {method: 'get'});
+            expect(route.name).to.equal('article');
+            expect(route.params.site).to.equal('finance');
+            expect(route.params.category).to.equal('news');
+            expect(route.params.alias).to.equal('test.html');
+        });
 
         it('should allow route to match multiple methods', function () {
             var route = 'multi_methods';


### PR DESCRIPTION
URLs with no query string, but with a hash fragment containing `?` have the portion of the hash fragment prior to the `?` erroneously included as part of the path.

For example, given `/foo#bar?baz`, the path should be `/foo`, but is instead `/foo#bar`.

From [rfc3986](https://tools.ietf.org/html/rfc3986#section-3.5):

> The characters slash ("/") and question mark ("?") are allowed to represent data within the fragment identifier.
