### PR TITLE
downgrade debug to work around problem with uglify

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     }
   ],
   "dependencies": {
-    "debug": "^4.0.0",
+    "debug": "^2.0.0",
     "path-to-regexp": "^1.1.1",
     "query-string": "^5.0.0"
   },


### PR DESCRIPTION
User reported issue in routr@2.1.1 (which uses debug@4) with uglify with error message like this:

```ERROR in vendor.888a7a787eb2a291282b.min.js from UglifyJs
    Unexpected token: name (index) [vendor.888a7a787eb2a291282b.min.js:79667,5]
```

Developers using routr can also choose to transpile `debug` module.  Downgrade to debug 2.x is fastest way to workaround this issue without requiring developers to make changes.