### PR TITLE
replace query-string with native URLSearchParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 3.0.0
+
+### Breaking Changes
+
+-   `routr` uses native `URLSearchParams` instead of `query-string`
+    library internally. If you need to support old browsers, you can
+    either add a `URLSearchParams` polyfill or inject `query-string`
+    when instantiating `routr`:
+
+```js
+router = new Routr(routes, {
+    queryLib: require('query-string'),
+});
+```
+
 ## 2.1.0
 
 -   [#37] Enhance makePath for routes with path array

--- a/lib/router.js
+++ b/lib/router.js
@@ -5,9 +5,31 @@
 'use strict';
 
 var pathToRegexp = require('path-to-regexp');
-var queryString = require('query-string');
 var DEFAULT_METHOD = 'GET';
 var cachedCompilers = {};
+
+var queryString = {
+    parse: function (string) {
+        var obj = {};
+
+        var params = new URLSearchParams(string);
+        params.forEach(function (value, key) {
+            obj[key] = value;
+        });
+
+        return obj;
+    },
+    stringify: function (obj) {
+        var params = new URLSearchParams();
+        for (var key in obj) {
+            if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                params.append(key, obj[key]);
+            }
+        }
+        params.sort();
+        return params.toString();
+    },
+};
 
 /**
  * @class Route

--- a/package-lock.json
+++ b/package-lock.json
@@ -1247,11 +1247,6 @@
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
     },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -2536,11 +2531,6 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2776,16 +2766,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
-    },
-    "query-string": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      }
     },
     "randombytes": {
       "version": "2.1.0",
@@ -3131,11 +3111,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
-    },
-    "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-width": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     }
   ],
   "dependencies": {
-    "path-to-regexp": "^1.1.1",
-    "query-string": "^5.0.0"
+    "path-to-regexp": "^1.1.1"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.2",


### PR DESCRIPTION
This change removes 40% of js from the final package. However it's not compatible with IE11. But 2 alternatives are possible:

a. to polyfill URLSearchParams
b. to pass `query-string` as `options.queryLib` to `Routr` constructor.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
