### PR TITLE
package.json: update path-to-regexp to latest version

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -55,7 +55,7 @@ function Route(name, config, options) {
         }
     }
     this.keys = [];
-    this.regexp = pathToRegexp(this.config.path, this.keys);
+    this.regexp = pathToRegexp.pathToRegexp(this.config.path, this.keys);
     this._queryLib = options.queryLib || queryString;
 }
 
@@ -200,7 +200,8 @@ Route.prototype._makePath = function (routePath, params, query) {
     var strQuery;
     if (typeof routePath === 'string') {
         compiler =
-            cachedCompilers[routePath] || pathToRegexp.compile(routePath);
+            cachedCompilers[routePath] ||
+            pathToRegexp.compile(routePath, { encode: encodeURIComponent });
         cachedCompilers[routePath] = compiler;
         url = compiler(params);
         if (query) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2037,7 +2037,8 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -2508,6 +2509,17 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
       }
     },
     "nopt": {
@@ -2624,12 +2636,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "requires": {
-        "isarray": "0.0.1"
-      }
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+      "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
     },
     "pathval": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     }
   ],
   "dependencies": {
-    "path-to-regexp": "^1.1.1"
+    "path-to-regexp": "^6.2.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.2",


### PR DESCRIPTION
2 main changes happened with `path-to-regexp` from v1 to v6:

- `pathToRegexp` is not in the the default export anymore (`pathToRegexp(path)` -> `pathToRegexp.pathToRegexp(path)`)
- It doesn't call `encodeURIComponent` when calling `compile` (`pathToRegexp.compile(path)` -> `pathToRegexp.compile(path, {encode: encodeURIComponent })`)

Regarding the last item, the test introduced in this [commit](https://github.com/yahoo/routr/commit/351dfe92db26eb7293da060f127d7bc9abcbfb13) was failing. It seems that we could not pass and undo the changes introduced in the commit. But this would also require to update `fluxible-router` and check if they still work together as expected.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
